### PR TITLE
Missing Comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ end
 # create a postgresql database
 postgresql_database 'mr_softie' do
   connection(
-    :host      => '127.0.0.1'
+    :host      => '127.0.0.1',
     :port      => 5432,
     :username  => 'postgres',
     :password  => node['postgresql']['password']['postgres']


### PR DESCRIPTION
Missing comma after :host entry stopped the postgres example from working when cut & pasted.