### PR TITLE
Fix invalid key in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ end
 # Vacuum a postgres database
 postgresql_database 'vacuum databases' do
   connection      postgresql_connection_info
-  database_table 'template1'
+  database_name 'template1'
   sql 'VACUUM FULL VERBOSE ANALYZE'
   action :query
 end


### PR DESCRIPTION
The key should be database_name to specify the database name, not database_table

Obvious fix.