### PR TITLE
Adding grant_option support back in for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Resources/Providers
 These resources aim to expose an abstraction layer for interacting with different RDBMS in a general way. Currently the cookbook ships with providers for MySQL, PostgreSQL and SQL Server. Please see specific usage in the __Example__ sections below. The providers use specific Ruby gems installed under Chef's Ruby environment to execute commands and carry out actions. These gems will need to be installed before the providers can operate correctly. Specific notes for each RDBS flavor:
 
 - MySQL: leverages the `mysql` gem which is installed as part of the `mysql-chef_gem` recipe. You must declare `include_recipe "database::mysql"` to include this in your recipe.
-- PostgreSQL: leverages the `pg` gem which is installed as part of the `postgresql::ruby` recipe. You must declare `include_recipe "database::postgresql"` to include this. 
+- PostgreSQL: leverages the `pg` gem which is installed as part of the `postgresql::ruby` recipe. You must declare `include_recipe "database::postgresql"` to include this.
 - SQL Server: leverages the `tiny_tds` gem which is installed as part of the `sql_server::client` recipe.
 
 This cookbook is not in charge of installing the Database Management System itself. Therefore, if you want to install MySQL, for instance, you should add `include_recipe "mysql::server"` in your recipe, or include `mysql::server` in the node run_list.
@@ -227,6 +227,8 @@ Manage users and user privileges in a RDBMS. Use the proper shortcut resource de
   :port, :username, :password
 - privileges: array of database privileges to grant user. used by the
   :grant action. default is :all
+- grant_option: appends 'WITH GRANT OPTION' to grant statement. used by
+  MySQL provider only. default is 'false'
 - host: host where user connections are allowed from. used by MySQL
   provider only. default is 'localhost'
 - table: table to grant privileges on. used by :grant action and MySQL

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -69,9 +69,14 @@ class Chef
             grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON #{@new_resource.database_name ? "`#{@new_resource.database_name}`" : '*'}.#{@new_resource.table ? "`#{@new_resource.table}`" : '*'} TO `#{@new_resource.username}`@`#{@new_resource.host}` IDENTIFIED BY "
             grant_statement += password
 
-            if (@new_resource.require_ssl) then
+            if @new_resource.require_ssl
               grant_statement += " REQUIRE SSL"
             end
+
+            if @new_resource.grant_option
+              grant_statement += " WITH GRANT OPTION"
+            end
+
             Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}#{filtered}]")
             db.query(grant_statement)
             @new_resource.updated_by_last_action(true)


### PR DESCRIPTION
Fixes accidental bug introduced in #62 that adds `WITH GRANT OPTION` for MySQL when `grant_option == true`