### PR TITLE
For compatibility with mysql_chef_gem 1.0

### DIFF
--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe 'mysql-chef_gem'
+mysql_chef_gem 'default' do
+  action :install
+end


### PR DESCRIPTION
In mysql_chef_gem the default recipe is removed  so the install action need to be specified now.
https://github.com/opscode-cookbooks/mysql-chef_gem/commit/40d7f00f17e1ff55d7e0d453927e08b0e15e9a69