### PR TITLE
allow grants on databases with funny names

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -131,7 +131,7 @@ class Chef
             converge_by "Granting privs for '#{new_resource.username}'@'#{new_resource.host}'" do
               begin
                 repair_sql = "GRANT #{new_resource.privileges.join(',')}"
-                repair_sql += " ON #{db_name}.#{tbl_name}"
+                repair_sql += " ON `#{db_name}`.#{tbl_name}"
                 repair_sql += " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
                 repair_sql += " '#{new_resource.password}'"
                 repair_sql += ' REQUIRE SSL' if new_resource.require_ssl


### PR DESCRIPTION
you can't grant on a DB with a dash in it without escaping the DB name.
http://bugs.mysql.com/bug.php?id=461