### PR TITLE
Fix mysql2_chef_gem resource to work with mysql 6.0.x cookbook

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -30,7 +30,7 @@ class Chef
         action :create do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql']
           end.run_action(:install)
 
           # test
@@ -66,7 +66,7 @@ class Chef
         action :drop do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql']
           end.run_action(:install)
 
           # test

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -30,7 +30,7 @@ class Chef
         action :create do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql']
             action :install
           end
           
@@ -63,7 +63,7 @@ class Chef
         action :drop do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql']
             action :install
           end
           


### PR DESCRIPTION
mysql_database and mysql_database_user resources fails if the developer is using mysql 6.0.x cookbook