### PR TITLE
Close mysql client only if it's set

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -112,7 +112,7 @@ class Chef
         end
 
         def close_test_client
-          @test_client.close
+          @test_client.close if @test_client
         rescue Mysql2::Error
           @test_client = nil
         end
@@ -130,7 +130,7 @@ class Chef
         end
 
         def close_repair_client
-          @repair_client.close
+          @repair_client.close if @repair_client
         rescue Mysql2::Error
           @repair_client = nil
         end

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -161,7 +161,7 @@ class Chef
         end
 
         def close_test_client
-          @test_client.close
+          @test_client.close if @test_client
         rescue Mysql2::Error
           @test_client = nil
         end
@@ -179,7 +179,7 @@ class Chef
         end
 
         def close_repair_client
-          @repair_client.close
+          @repair_client.close if @repair_client
         rescue Mysql2::Error
           @repair_client = nil
         end


### PR DESCRIPTION
Ensure we call the `close` method on mysql clients only when the client has been set already.

See #112.