### PR TITLE
No backticks for global privileges

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -102,7 +102,7 @@ class Chef
             return true if (/(\A\*[0-9A-F]{40}\z)/i).match(new_resource.password)
           end
 
-          db_name = new_resource.database_name ? new_resource.database_name : '*'
+          db_name = new_resource.database_name ? "`#{new_resource.database_name}`" : '*'
           tbl_name = new_resource.table ? new_resource.table : '*'
 
           # Test
@@ -131,7 +131,7 @@ class Chef
             converge_by "Granting privs for '#{new_resource.username}'@'#{new_resource.host}'" do
               begin
                 repair_sql = "GRANT #{new_resource.privileges.join(',')}"
-                repair_sql += " ON `#{db_name}`.#{tbl_name}"
+                repair_sql += " ON #{db_name}.#{tbl_name}"
                 repair_sql += " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
                 repair_sql += " '#{new_resource.password}'"
                 repair_sql += ' REQUIRE SSL' if new_resource.require_ssl


### PR DESCRIPTION
#109 allowed db name escape, but introduced a bug as 
```
'*'
```
was replaced by 
```
`*`
```
triggering errors like : 
```
ERROR 1221 (HY000): Incorrect usage of DB GRANT and GLOBAL PRIVILEGES
```

This fix is like #114 but allows to keep name escape for DB.