### PR TITLE
Adding specific example for a named mysql instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,18 @@ mysql_database 'oracle_rules' do
   action :create
 end
 ```
-
+```ruby
+# Create a mysql database on a named mysql instance
+mysql_database 'oracle_rools' do
+  connection(
+    :host     => '127.0.0.1',
+    :username => 'root',
+    :socket   => "/var/run/mysql-#{instance-name}/mysqld.sock"
+    :password => node['mysql']['server_root_password']
+  )
+  action :create
+end       
+```
 ```ruby
 # Create a sql server database
 sql_server_database 'mr_softie' do


### PR DESCRIPTION
I added specific example usage when using v6.0.0+ of the MySQL cookbook as it moves from a default socket location to an instance-specific socket location.  I ate up a day of time trying to figure out why the upgrade of the underlying MySQL cookbook was causing a previously working cookbook to break.