### PR TITLE
Allow mysqluser provider with unspecified version

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -30,7 +30,7 @@ class Chef
         action :create do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql'] && node['mysql']['version']
             action :install
           end
           


### PR DESCRIPTION
Ohai Chefs !

As it was previously done with Chef::Provider::Database::Mysql provider (https://github.com/opscode-cookbooks/database/blob/master/libraries/provider_database_mysql.rb#L33), we need to make client_version optionnal if we target to use this provider with MariaDB (currently it's broken, even when I try to force all mysql2 gem providers to MariaDB ones).

This is a very minor change btw, but it helps a lot,
Thanks