### PR TITLE
Ensure mysql2 gem is installed when calling the :grant action in mysql_d...

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -97,6 +97,12 @@ class Chef
         end
 
         action :grant do
+          # install mysql2 gem into Chef's environment
+          mysql2_chef_gem 'default' do
+            client_version node['mysql']['version']
+            action :install
+          end
+
           # gratuitous function
           def ishash?
             return true if (/(\A\*[0-9A-F]{40}\z)/i).match(new_resource.password)


### PR DESCRIPTION
mysql_database_user makes sure the mysql2_chef_gem is installed for the :create and :delete actions, but lacks the same logic for the :grant action. This patch aims to fix this issue.