### PR TITLE
Add missing require statements in mysql provider and resource files.

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require File.join(File.dirname(__FILE__), 'provider_database_mysql')
+
 class Chef
   class Provider
     class Database
@@ -33,7 +35,7 @@ class Chef
             client_version node['mysql']['version']
             action :install
           end
-          
+
           # test
           user_present = nil
           begin
@@ -66,7 +68,7 @@ class Chef
             client_version node['mysql']['version']
             action :install
           end
-          
+
           # test
           user_present = nil
           begin

--- a/libraries/resource_mysql_database.rb
+++ b/libraries/resource_mysql_database.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require File.join(File.dirname(__FILE__), 'provider_database_mysql')
+
 class Chef
   class Resource
     class MysqlDatabase < Chef::Resource::Database


### PR DESCRIPTION
A couple of missing require statements can cause recipe compilation problems if files are loaded in a certain order by Chef.