### PR TITLE
fix tests for mysql

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -66,7 +66,7 @@ class Chef
         action :drop do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql'] && node['mysql']['version']
           end.run_action(:install)
 
           # test

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -30,10 +30,10 @@ class Chef
         action :create do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql'] && node['mysql']['version']
             action :install
           end
-          
+
           # test
           user_present = nil
           begin
@@ -63,10 +63,10 @@ class Chef
         action :drop do
           # install mysql2 gem into Chef's environment
           mysql2_chef_gem 'default' do
-            client_version node['mysql']['version']
+            client_version node['mysql']['version'] if node['mysql'] && node['mysql']['version']
             action :install
           end
-          
+
           # test
           user_present = nil
           begin

--- a/test/fixtures/cookbooks/mysql_database_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/mysql_database_test/recipes/default.rb
@@ -7,7 +7,7 @@ connection_info = {
 
 # Create a mysql_service to test against
 mysql_service 'default' do
-  version node['mysql']['version']
+  version node['mysql']['version'] if node['mysql'] && node['mysql']['version']
   port '3306'
   initial_root_password 'ub3rs3kur3'
   action [:create, :start]


### PR DESCRIPTION
The tests weren't passing for mysql `kitchen converge` because of changes in the mysql cookbook.   This gets the tests passing again.