### PR TITLE
Fix no database selected error for mysql queries

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -143,7 +143,8 @@ class Chef
             socket: new_resource.connection[:socket],
             username: new_resource.connection[:username],
             password: new_resource.connection[:password],
-            port: new_resource.connection[:port]
+            port: new_resource.connection[:port],
+            database: new_resource.database_name
             )
         end
 


### PR DESCRIPTION
When performing queries on mysql database, the database option is not
set properly for the mysql2 client. Set this option to allow to perform
database queries like 'create table' etc..

I don't know if it's necessary to set this option for `test_client` and `repair_client`,
only `query_client` is affected here.