### PR TITLE
[COOK-4555] #127 Adding db user fails and replication support

### DIFF
--- a/libraries/provider_database_postgresql.rb
+++ b/libraries/provider_database_postgresql.rb
@@ -100,6 +100,16 @@ class Chef
           ret
         end
 
+        # Test if text is psql keyword
+        def keyword?(text)
+          begin
+            result = db('template1').exec_params('select * from pg_get_keywords() where word = $1', [text.downcase]).num_tuples != 0
+          ensure
+            close
+          end
+          result
+        end
+
         #
         # Specifying the database in the connection parameter for the postgres resource is not recommended.
         #

--- a/libraries/provider_database_postgresql_user.rb
+++ b/libraries/provider_database_postgresql_user.rb
@@ -42,7 +42,7 @@ class Chef
               options += " #{@new_resource.createdb ? 'CREATEDB' : 'NOCREATEDB'}"
               options += " #{@new_resource.createrole ? 'CREATEROLE' : 'NOCREATEROLE'}"
               options += " #{@new_resource.login ? 'LOGIN' : 'NOLOGIN'}"
-              options += " #{@new_resource.replication ? 'REPLICATION' : 'NOREPLICATION'}"
+              options += " #{@new_resource.replication ? 'REPLICATION' : 'NOREPLICATION'}" if replication_keyword?
               options += " #{@new_resource.superuser ? 'SUPERUSER' : 'NOSUPERUSER'}"
 
               statement = "CREATE USER \"#{@new_resource.username}\""
@@ -88,6 +88,14 @@ class Chef
         end
 
         private
+        def replication_keyword?
+          begin
+            replication_keyword = db('template1').query("select * from pg_get_keywords() where word = 'replication'").num_tuples != 0
+          ensure
+            close
+          end
+          replication_keyword
+        end
 
         def exists?
           begin

--- a/libraries/provider_database_postgresql_user.rb
+++ b/libraries/provider_database_postgresql_user.rb
@@ -42,7 +42,7 @@ class Chef
               options += " #{@new_resource.createdb ? 'CREATEDB' : 'NOCREATEDB'}"
               options += " #{@new_resource.createrole ? 'CREATEROLE' : 'NOCREATEROLE'}"
               options += " #{@new_resource.login ? 'LOGIN' : 'NOLOGIN'}"
-              options += " #{@new_resource.replication ? 'REPLICATION' : 'NOREPLICATION'}" if replication_keyword?
+              options += " #{@new_resource.replication ? 'REPLICATION' : 'NOREPLICATION'}" if keyword?('REPLICATION')
               options += " #{@new_resource.superuser ? 'SUPERUSER' : 'NOSUPERUSER'}"
 
               statement = "CREATE USER \"#{@new_resource.username}\""
@@ -88,14 +88,6 @@ class Chef
         end
 
         private
-        def replication_keyword?
-          begin
-            replication_keyword = db('template1').query("select * from pg_get_keywords() where word = 'replication'").num_tuples != 0
-          ensure
-            close
-          end
-          replication_keyword
-        end
 
         def exists?
           begin


### PR DESCRIPTION
*In PostgresSQL 9.1, the REPLICATION and NOREPLICATION keywords
were added.
*Adding replication support causes earlier clients to see see a syntax
error causing failure for users to add. This was evident in #127 
as well as the jira cookbook on centos6.
*This fix uses a pgsql function to check for the existence of
the replication keyword. If it does not exist, the options will
not be used, avoiding the syntax error and restoring proper operation.