### PR TITLE
*BUG FIX* Use a more reliable method of determining whether the Postgres server accepts the REPLICATION attribute on user creation.

### DIFF
--- a/libraries/provider_database_postgresql.rb
+++ b/libraries/provider_database_postgresql.rb
@@ -100,10 +100,12 @@ class Chef
           ret
         end
 
-        # Test if text is psql keyword
-        def keyword?(text)
+        # Verify the postgres server's version number is greater than the integer passed in
+        def version_greater_than?(desired_version_int)
           begin
-            result = db('template1').exec_params('select * from pg_get_keywords() where word = $1', [text.downcase]).num_tuples != 0
+            ret = db('template1').exec('SHOW server_version_num;')
+            server_version_int = ret.getvalue(0,0).to_i
+            result = server_version_int > desired_version_int
           ensure
             close
           end

--- a/libraries/provider_database_postgresql.rb
+++ b/libraries/provider_database_postgresql.rb
@@ -105,11 +105,10 @@ class Chef
           begin
             ret = db('template1').exec('SHOW server_version_num;')
             server_version_int = ret.getvalue(0,0).to_i
-            result = server_version_int > desired_version_int
           ensure
             close
           end
-          result
+          server_version_int > desired_version_int
         end
 
         #

--- a/libraries/provider_database_postgresql_user.rb
+++ b/libraries/provider_database_postgresql_user.rb
@@ -42,7 +42,7 @@ class Chef
               options += " #{@new_resource.createdb ? 'CREATEDB' : 'NOCREATEDB'}"
               options += " #{@new_resource.createrole ? 'CREATEROLE' : 'NOCREATEROLE'}"
               options += " #{@new_resource.login ? 'LOGIN' : 'NOLOGIN'}"
-              options += " #{@new_resource.replication ? 'REPLICATION' : 'NOREPLICATION'}" if keyword?('REPLICATION')
+              options += " #{@new_resource.replication ? 'REPLICATION' : 'NOREPLICATION'}" if version_greater_than?(90100)
               options += " #{@new_resource.superuser ? 'SUPERUSER' : 'NOSUPERUSER'}"
 
               statement = "CREATE USER \"#{@new_resource.username}\""


### PR DESCRIPTION
The change introduced in https://github.com/opscode-cookbooks/database/pull/132 breaks the replication attribute on the `postgresql_database_user` LWRP and bypasses it entirely, even if the Postgres server is capable of understanding the replication keyword.  This might be due to a bug in Postgres server, as it seems the `select* from pg_get_keywords()` query used in https://github.com/opscode-cookbooks/database/pull/132 never returns 'replication', even if the Postgres version can in fact understand it.

This pull request uses a more reliable `version_greater_than` method to isolate older Postgresql versions that can't support the replication keyword in a `create user` statement.