### PR TITLE
Adding the "missing" `flags` option for MySQL connections

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -143,7 +143,8 @@ class Chef
             socket: new_resource.connection[:socket],
             username: new_resource.connection[:username],
             password: new_resource.connection[:password],
-            port: new_resource.connection[:port]
+            port: new_resource.connection[:port],
+            flags: new_resource.connection[:flags]
             )
         end
 


### PR DESCRIPTION
By adding this option to the connection hash, you can enable some really helpful features when using the MySQL provider right out of the box…