### PR TITLE
Use unescaped db name in field value when performing mysql grant

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -101,7 +101,7 @@ class Chef
             test_sql = 'SELECT * from mysql.db'
             test_sql += " WHERE User='#{new_resource.username}'"
             test_sql += " AND Host='#{new_resource.host}'"
-            test_sql += " AND Db='#{db_name}'"
+            test_sql += " AND Db='#{new_resource.database_name}'"
             test_sql_results = test_client.query test_sql
 
             incorrect_privs = true if test_sql_results.size == 0


### PR DESCRIPTION
Using the escaped db_name results in a ```SELECT ... Db='`db_name`'```, which results in no rows being found for `'db_name'`, hence grant actions will always execute a converge.

Considering this an `Obvious Fix`.