### PR TITLE
Query client needs to include the database

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -143,7 +143,8 @@ class Chef
             socket: new_resource.connection[:socket],
             username: new_resource.connection[:username],
             password: new_resource.connection[:password],
-            port: new_resource.connection[:port]
+            port: new_resource.connection[:port],
+            database: new_resource.connection.fetch(:database, new_resource.database_name)
             )
         end
 

--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -91,6 +91,7 @@ class Chef
           begin
             query_sql = new_resource.sql
             Chef::Log.debug("Performing query [#{query_sql}]")
+            query_client.select_db(new_resource.connection.fetch(:database, new_resource.database_name))
             query_client.query(query_sql)
           ensure
             close_query_client

--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -91,7 +91,6 @@ class Chef
           begin
             query_sql = new_resource.sql
             Chef::Log.debug("Performing query [#{query_sql}]")
-            query_client.select_db(new_resource.connection.fetch(:database, new_resource.database_name))
             query_client.query(query_sql)
           ensure
             close_query_client


### PR DESCRIPTION
Queries will not run without a configured database name.

Resolves #149